### PR TITLE
Lazy load $zilla->version and other attributes.

### DIFF
--- a/lib/Dist/Zilla/Plugin/Run/AfterBuild.pm
+++ b/lib/Dist/Zilla/Plugin/Run/AfterBuild.pm
@@ -15,7 +15,7 @@ sub after_build {
     my ($self, $param) = @_;
   $self->call_script({
     dir =>  $param->{ build_root },
-    pos => [$param->{ build_root }, $self->zilla->version]
+    pos => [$param->{ build_root }, sub { $self->zilla->version }]
   });
 }
 

--- a/lib/Dist/Zilla/Plugin/Run/AfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/Run/AfterRelease.pm
@@ -15,7 +15,7 @@ sub after_release {
   my ( $self, $archive ) = @_;
   $self->call_script({
     archive =>  $archive,
-    pos     => [$archive, $self->zilla->version]
+    pos     => [$archive, sub { $self->zilla->version }]
   });
 }
 

--- a/lib/Dist/Zilla/Plugin/Run/BeforeBuild.pm
+++ b/lib/Dist/Zilla/Plugin/Run/BeforeBuild.pm
@@ -14,7 +14,7 @@ use namespace::autoclean;
 sub before_build {
     my ($self) = @_;
   $self->call_script({
-    pos => [$self->zilla->version]
+    pos => [sub { $self->zilla->version }]
   });
 }
 

--- a/lib/Dist/Zilla/Plugin/Run/Role/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/Run/Role/Runner.pm
@@ -155,25 +155,29 @@ sub build_formatter {
         d => $dir,
 
         # dist name
-        n => $self->zilla->name,
+        n => sub { $self->zilla->name },
 
         # backward compatibility (don't error)
         s => '',
 
         # portability
         p => $path_separator,
-        x => $self->perlpath,
+        x => sub { $self->perlpath },
     };
 
     # available during build, not mint
     unless( $params->{minting} ){
-        $codes->{v} = $self->zilla->version;
+        $codes->{v} = sub { $self->zilla->version };
     }
 
     # positional replace (backward compatible)
     if( my @pos = @{ $params->{pos} || [] } ){
         # where are you defined-or // operator?
-        $codes->{s} = sub { my $s = shift(@pos); defined($s) ? $s : '' };
+        $codes->{s} = sub {
+            my $s = shift(@pos);
+            $s = $s->() if ref $s eq 'CODE';
+            defined($s) ? $s : '';
+        };
     }
 
     return String::Formatter->new({ codes => $codes });


### PR DESCRIPTION
The reason for this is, with plugins such as [VersionFromModule], calling `$zilla->version` in the BeforeBuild phase causes a missing main_module, because file gathering hasn't happened yet.

Maybe these plugin providers have to be fixed so as it won't die in such cases, but lazy evaluating these methods in Run does no harm and makes sense to me.
