### PR TITLE
Add %t to support trial releases

### DIFF
--- a/lib/Dist/Zilla/Plugin/Run.pm
+++ b/lib/Dist/Zilla/Plugin/Run.pm
@@ -102,6 +102,7 @@ for passing as arguments to the specified commands
 * C<%n> the dist name
 * C<%p> path separator ('/' on Unix, '\\' on Win32... useful for cross-platform dist.ini files)
 * C<%v> the dist version
+* C<%t> C<-TRIAL> if the release is a trial release, otherwise the empty string
 * C<%x> full path to the current perl interpreter (like $^X but from L<Config>)
 
 Additionally C<%s> is retained for backward compatibility.

--- a/lib/Dist/Zilla/Plugin/Run/Role/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/Run/Role/Runner.pm
@@ -221,6 +221,7 @@ sub build_formatter {
     # available during build, not mint
     unless( $params->{minting} ){
         $codes->{v} = sub { $self->zilla->version };
+        $codes->{t} = sub { $self->zilla->is_trial ? '-TRIAL' : '' };
     }
 
     # positional replace (backward compatible)


### PR DESCRIPTION
It expands to -TRIAL if the release is a trial release, otherwise the
empty string.  This matches the Git::Tag plugin, for example, and lets
configs use %v%t to pass x.y-TRIAL to external commands when
appropriate.
