### PR TITLE
use $ENV{TRIAL} instead of is_trial mutator

### DIFF
--- a/t/10_build_phase.t
+++ b/t/10_build_phase.t
@@ -6,6 +6,9 @@ use Test::DZil;
 use Path::Tiny;
 use Test::Deep;
 
+# protect from external environment
+local $ENV{TRIAL};
+
 sub test_build {
     my %test = @_;
 
@@ -47,7 +50,7 @@ SCRIPT
     );
 
     $tzil->chrome->logger->set_debug(1);
-    $tzil->is_trial(1) if $test{trial};
+    local $ENV{TRIAL} = 1 if $test{trial};
     $tzil->build;
 
     my $before_build_result = path($tzil->tempdir, qw(source BEFORE_BUILD.txt));


### PR DESCRIPTION
is_trial is likely to become read-only as a part of
rjbs/Dist-Zilla#438 which adds support for customizing
release status

cc: @ether
