### PR TITLE
Fix windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+skip_tags: true
+
+cache:
+  - C:\strawberry -> appveyor.yml
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl -y
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm -n Dist::Zilla
+  - dzil authordeps --missing | cpanm -n
+  - dzil listdeps --author --missing | cpanm
+
+build_script:
+  - perl -e 2
+
+test_script:
+  - dzil test
+
+# notifications:
+# To get Github PR notifications from AppVeyor, get an auth token from Github,
+# encrypt it at https://ci.appveyor.com/tools/encrypt and put it into the
+# secure field
+#  - provider: GitHubPullRequest
+#    auth_token:
+#      secure: ...

--- a/t/30_all_phases.t
+++ b/t/30_all_phases.t
@@ -47,7 +47,7 @@ SCRIPT
     my %f = (
         a => 'DZT-Sample-0.001.tar.gz',
         n => 'DZT-Sample',
-        d => path($tzil->tempdir)->child('build')->canonpath, # use OS-specific path separators
+        d => path($tzil->tempdir)->child('build'),
         v => '0.001',
         x => Dist::Zilla::Plugin::Run::Role::Runner->current_perl_path,
     );

--- a/t/70-eval.t
+++ b/t/70-eval.t
@@ -52,7 +52,7 @@ my $source_dir = path($tzil->tempdir)->child('source');
 my %f = (
     a => 'DZT-Sample-0.001.tar.gz',
     n => 'DZT-Sample',
-    d => path($tzil->tempdir)->child('build')->canonpath, # use OS-specific path separators
+    d => path($tzil->tempdir)->child('build'),
     v => '0.001',
     x => Dist::Zilla::Plugin::Run::Role::Runner->current_perl_path,
 );


### PR DESCRIPTION
On a fresh Strawberry Perl 5.20.1 install (ie. AppVeyor) this is failing.

I found getting all the paths OS canonical a bit much, so I changed the tests. It's only human readable stuff and gets Windows passing.

I'm concerned that I couldn't find why this started failing. I see from CPAN Testers that it's been passing on Win32. Did something in the dependency chain change? Unfortunately CPAN Testers is erroring when I try to look at the passing results.