### PR TITLE
fix travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
----
 sudo: false
 addons:
   apt:
     packages:
       - aspell
-before_install:
-  - export AUTOMATED_TESTING=1
-  - export HARNESS_OPTIONS=j10:c
-  - export HARNESS_TIMER=1
-  - git config --global user.name "TravisCI"
-  - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
-install:
-  - export AUTOMATED_TESTING=1
-  - export HARNESS_OPTIONS=j1:c
-  - export HARNESS_TIMER=1
-  - cpanm JSON::PP
-  - cpanm --verbose --skip-satisfied Dist::Zilla
-  - cpanm --verbose Dist::Zilla::App::Command::stale
-  - "dzil authordeps --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm"
-  - "dzil listdeps --author --missing | grep -vP '[^\\w:]' | cpanm"
+      - aspell-en
 language: perl
 perl:
+  - "blead"
+  - "5.24"
   - "5.22"
   - "5.20"
   - "5.18"
@@ -28,8 +15,40 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+  - "5.8"
+  - 5.8.8
+matrix:
+  include:
+    - perl: 5.18
+      env: COVERAGE=1
+  allow_failures:
+    - perl: "blead"
+    - perl: "5.12"
+    - perl: "5.10"
+    - perl: "5.8"
+    - perl: 5.8.8
+before_install:
+  # - git config --global user.name "TravisCI"
+  # - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
+install:
+  - cpanm JSON::PP
+  - cpanm --skip-satisfied Dist::Zilla
+  - cpanm --skip-satisfied --force Dist::Zilla::App::Command::stale
+  - "dzil authordeps | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --force --notest"
+  - "dzil listdeps | grep -vP '[^\\w:]' | cpanm --force --notest"
+  - cpan-install --deps       # installs prereqs, including recommends
+  - cpan-install --coverage   # installs converage prereqs, if enabled
+before_script:
+  - coverage-setup
 script:
-  - export AUTOMATED_TESTING=1
-  - export HARNESS_OPTIONS=j10:c
-  - export HARNESS_TIMER=1
-  - dzil test --author --smoke
+  - export AUTOMATED_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
+  # - dzil test --author --smoke
+  - prove -l -j$(test-jobs) $(test-files)   # parallel testing
+after_success:
+  - coverage-report

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-Plugin-Run
 
 {{$NEXT}}
+  - PENDING
 
 0.043     2016-02-15 04:20:20Z
   - new [Run::BeforeArchive] plugin


### PR DESCRIPTION
* use "--force" and module install overkill to enable travis-ci builds and coverage reports

`perl` versions earlier than 5.14 are still unable to build/test successfully. But this is a good start, and it gives a baseline to evaluate PRs.

note: a minor change, adding preliminary text to "Changes", was required to pass the "xt/release/changes_has_content.t" test.