### PR TITLE
This fixes testing failures on MSWin32.

### DIFF
--- a/t/10_build_phase.t
+++ b/t/10_build_phase.t
@@ -76,9 +76,10 @@ SCRIPT
         ok( (  -f $no_trial_file), 'non-trial - file present' );
         is $no_trial_file->slurp_raw, ':-P', 'non-trial content';
 
-        my $script = $build_dir->child('script','no_trial.pl')->canonpath;   # use OS-specific path separators
+        my $script = quotemeta $build_dir->child('script','no_trial.pl')->canonpath;   # use OS-specific path separators
+		$script =~ s/\\\\/[\\\\\/]/g if  $^O eq 'MSWin32';
         like $tzil->log_messages->[-2],
-            qr{\[Run::AfterBuild\] executing: .+ \Q$script\E .+},
+            qr{\[Run::AfterBuild\] executing: .+ $script .+},
             'logged execution';
 
         like $tzil->log_messages->[-1],


### PR DESCRIPTION
The path is being converted to "canonical" mode, but the actual path contains mixed path sparator characters.  I propose matching on either separator character on Windows.  This introduces some
platform specific code, which I am not thrilled about.

Examples of this failure can be seen on cpantesters here:

http://matrix.cpantesters.org/?dist=Dist-Zilla-Plugin-Run%200.047;os=mswin32;reports=1

There may be a better way to handle this without introducing platform specific code into the test.  If there is a better way to handle this, then at least this PR illustrates the problem.